### PR TITLE
bugfix: fix parameter names

### DIFF
--- a/src/components/paramStyle/ParamStyleHandler.js
+++ b/src/components/paramStyle/ParamStyleHandler.js
@@ -6,7 +6,7 @@ export const StyleList = ["default", "1", "2", "3", "hide"];
 
 export default class ParamStyleHandler {
     constructor(getStyle, setStyle) {
-        this.paramNames = ["ID", "Part", "Bone", "Damage", "Angle", "KBG", "FKB", "BKB", "Size", "X", "Y", "Z", "X2", "Y2", "Z2", "Hitlag", "SDI", "Clang/Rebound", "FacingRestrict", "SetWeight", "ShieldDamage", "Trip", "Rehit", "Reflectable", "Absorbable", "Flinchless", "DisableHitlag", "Direct/Indirect", "Ground/Air", "Hitbits", "CollisionPart", "FriendlyFire", "Effect", "SFXLevel", "SFXType", "Type"];
+        this.paramNames = ["ID", "Part", "Bone", "Damage", "Angle", "KBG", "FKB", "BKB", "Size", "X", "Y", "Z", "X2", "Y2", "Z2", "Hitlag", "SDI", "Clang_Rebound", "FacingRestrict", "SetWeight", "ShieldDamage", "Trip", "Rehit", "Reflectable", "Absorbable", "Flinchless", "DisableHitlag", "Direct_Hitbox", "Ground_or_Air", "Hitbits", "CollisionPart", "FriendlyFire", "Effect", "SFXLevel", "SFXType", "Type"];
         this.localStorageKey = "ssbu-param-styles";
         this.getStyle = getStyle;
         this.setStyle = setStyle;


### PR DESCRIPTION
This PR fixes a bug in the filtering/coloring feature which I added previously in #3.

## Details
At some point (after #3 is merged), the names of some parameters are changed in the following way:

- `Clang/Rebound` -> `Clang_Rebound`
- `Direct/Indirect` -> `Direct_Hitbox`
- `Ground/Air` -> `Ground_or_Air`

This caused a bug since the names in the filtering/coloring feature are not changed.