### PR TITLE
Description of parameters of ATTACKs in ScriptView

### DIFF
--- a/src/assets/css/characters.css
+++ b/src/assets/css/characters.css
@@ -134,22 +134,22 @@ td{
     color: rgb(136, 0, 0);
 }
 
-.script span.param-style-1 span.script-param-content {
+.script .param-style-1 span.script-param-content {
   background: peachpuff;
   background-clip: content-box;
 }
 
-.script span.param-style-2 span.script-param-content {
+.script .param-style-2 span.script-param-content {
   background: paleturquoise;
   background-clip: content-box;
 }
 
-.script span.param-style-3 span.script-param-content {
+.script .param-style-3 span.script-param-content {
   background: palegreen;
   background-clip: content-box;
 }
 
-.script span.param-style-hide {
+.script .param-style-hide {
   display: none;
 }
 
@@ -158,8 +158,13 @@ td{
   display: inline-block;
 }
 
-.script-param {
+label.script-param {
   position: relative;
+  font-weight: normal; /* overwrite font-weight for label given in bootstrap.css */
+}
+
+.script-param input[type="checkbox"] {
+  display: none;
 }
 .script-param .description {
   display: none;
@@ -184,7 +189,7 @@ td{
   color: red;
 }
 
-.script-param-content:focus + .description {
+input[type="checkbox"]:checked + .description {
   display: inline-block;
   z-index: 1;
   top: 20px;

--- a/src/assets/css/characters.css
+++ b/src/assets/css/characters.css
@@ -168,7 +168,7 @@ td{
   font-family: sans-serif;
 }
 
-.script-param-content:hover + .description {
+.script-param-content:focus + .description {
   display: inline-block;
   z-index: 1;
   top: 20px;

--- a/src/assets/css/characters.css
+++ b/src/assets/css/characters.css
@@ -170,6 +170,13 @@ td{
 
 .script-param .description .description-script {
   font-family: 'Ubuntu Mono', monospace;
+  background: rgb(240, 240, 240);
+  color: rgb(68, 68, 68);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding-bottom: 0;
+  margin-bottom: 4px;
+  margin-right: 2px;
 }
 
 .script-param-content:focus + .description {

--- a/src/assets/css/characters.css
+++ b/src/assets/css/characters.css
@@ -176,7 +176,8 @@ td{
   border-radius: 4px;
   padding-bottom: 0;
   margin-bottom: 4px;
-  margin-right: 2px;
+  margin-left: 4px;
+  margin-right: 4px;
 }
 
 .script-param .description .description-script.current-value {

--- a/src/assets/css/characters.css
+++ b/src/assets/css/characters.css
@@ -168,12 +168,19 @@ td{
   font-family: sans-serif;
 }
 
+.script-param .description .description-script {
+  font-family: 'Ubuntu Mono', monospace;
+}
+
 .script-param-content:focus + .description {
   display: inline-block;
   z-index: 1;
   top: 20px;
   left: 0px;
-  width: 300px;
+  width: 500px;
+  padding: 2px;
+  border: 1px solid sandybrown;
+  border-radius: 5px;
 }
 
 .script-container {

--- a/src/assets/css/characters.css
+++ b/src/assets/css/characters.css
@@ -149,16 +149,19 @@ td{
   background-clip: content-box;
 }
 
+/* This is done in src/util/ScriptParam.js by using React */
+/*
 .script .param-style-hide {
   display: none;
 }
+*/
 
 .script-param-content {
   cursor: pointer;
   display: inline-block;
 }
 
-label.script-param {
+.script-param label {
   position: relative;
   font-weight: normal; /* overwrite font-weight for label given in bootstrap.css */
 }

--- a/src/assets/css/characters.css
+++ b/src/assets/css/characters.css
@@ -165,6 +165,7 @@ td{
   display: none;
   position: absolute;
   background-color: lightyellow;
+  font-family: sans-serif;
 }
 
 .script-param-content:hover + .description {

--- a/src/assets/css/characters.css
+++ b/src/assets/css/characters.css
@@ -153,6 +153,28 @@ td{
   display: none;
 }
 
+.script-param-content {
+  cursor: pointer;
+  display: inline-block;
+}
+
+.script-param {
+  position: relative;
+}
+.script-param .description {
+  display: none;
+  position: absolute;
+  background-color: lightyellow;
+}
+
+.script-param-content:hover + .description {
+  display: inline-block;
+  z-index: 1;
+  top: 20px;
+  left: 0px;
+  width: 300px;
+}
+
 .script-container {
   display: flex;
   flex-direction: row;

--- a/src/assets/css/characters.css
+++ b/src/assets/css/characters.css
@@ -179,6 +179,10 @@ td{
   margin-right: 2px;
 }
 
+.script-param .description .description-script.current-value {
+  color: red;
+}
+
 .script-param-content:focus + .description {
   display: inline-block;
   z-index: 1;

--- a/src/components/ScriptList.js
+++ b/src/components/ScriptList.js
@@ -23,8 +23,8 @@ class ScriptList extends Component {
 
     var scripts = this.state.data.Scripts[this.state.article];
 
-    this.state.script = scripts[27];
-    this.state.scriptIndex = 27;
+    this.state.script = scripts[0];
+    this.state.scriptIndex = 0;
     this.state.allScripts = scripts;
 
   }

--- a/src/components/ScriptList.js
+++ b/src/components/ScriptList.js
@@ -23,8 +23,8 @@ class ScriptList extends Component {
 
     var scripts = this.state.data.Scripts[this.state.article];
 
-    this.state.script = scripts[0];
-    this.state.scriptIndex = 0;
+    this.state.script = scripts[27];
+    this.state.scriptIndex = 27;
     this.state.allScripts = scripts;
 
   }

--- a/src/util/ScriptParam.js
+++ b/src/util/ScriptParam.js
@@ -6,6 +6,8 @@ export function ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramS
     const equal = p2;
     const value = p3;
     const commaOrParen = p4;
+    const comma = (commaOrParen === ",") ? "," : "";
+    const paren = (commaOrParen === ")") ? ")" : "";
     let className = `script-param-${paramName}`;
     if (paramName in paramStyles) {
         className += ` param-style-${paramStyles[paramName]}`
@@ -19,8 +21,8 @@ export function ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramS
             <input type="checkbox" name="checkbox"/>
             <div className='description'>
               {GetDescriptionForParam(paramName, value)}
-            </div>
-          </label>{commaOrParen}
+            </div>{comma}
+          </label>{paren}
         </span>
     );
 }

--- a/src/util/ScriptParam.js
+++ b/src/util/ScriptParam.js
@@ -147,7 +147,7 @@ function DescribeCandidate(candidate, description, value) {
         className += " current-value";
     }
     return (
-        <div>
+        <div key={candidate}>
           <span className={className}>{candidate}</span>
           {description}
         </div>

--- a/src/util/ScriptParam.js
+++ b/src/util/ScriptParam.js
@@ -67,11 +67,11 @@ function GetDescriptionForParam(paramName) {
         DisableHitlag: "Flag that makes hitlag = 0 regardless of damage and hitlag multipliers when enabled",
         Direct_Hitbox: "",
         Ground_or_Air: (<span>
-          <span class='description-script'>COLLISION_SITUATION_MASK_A</span>
+          <span className='description-script'>COLLISION_SITUATION_MASK_A</span>
           hits opponents in air<br/>
-          <span class='description-script'>COLLISION_SITUATION_MASK_G</span>
+          <span className='description-script'>COLLISION_SITUATION_MASK_G</span>
           hits opponents on ground<br/>
-          <span class='description-script'>COLLISION_SITUATION_MASK_GA</span>
+          <span className='description-script'>COLLISION_SITUATION_MASK_GA</span>
           hits opponents both in air and on ground
         </span>),
         Hitbits: "Value where each bit enables it to hit certain hurtboxes like characters, stage elements, items and enemies",

--- a/src/util/ScriptParam.js
+++ b/src/util/ScriptParam.js
@@ -12,14 +12,15 @@ export function ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramS
     }
     return ReactDOMServer.renderToStaticMarkup(
         <span>
-          <span className={`script-param ${className}`}>
-            <span className='script-param-content' tabIndex='-1'>
+          <label className={`script-param ${className}`}>
+            <span className='script-param-content'>
               {paramName}{equal}<span className='script-param-value'>{value}</span>
             </span>
+            <input type="checkbox" name="checkbox"/>
             <div className='description'>
               {GetDescriptionForParam(paramName, value)}
             </div>
-          </span>{commaOrParen}
+          </label>{commaOrParen}
         </span>
     );
 }

--- a/src/util/ScriptParam.js
+++ b/src/util/ScriptParam.js
@@ -10,11 +10,14 @@ export function ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramS
     const paren = (commaOrParen === ")") ? ")" : "";
     let className = `script-param-${paramName}`;
     if (paramName in paramStyles) {
+        if (paramStyles[paramName] === "hide") {
+            return paren;
+        }
         className += ` param-style-${paramStyles[paramName]}`
     }
     return ReactDOMServer.renderToStaticMarkup(
-        <span>
-          <label className={`script-param ${className}`}>
+        <span className={`script-param ${className}`}>
+          <label>
             <span className='script-param-content'>
               {paramName}{equal}<span className='script-param-value'>{value}</span>
             </span>

--- a/src/util/ScriptParam.js
+++ b/src/util/ScriptParam.js
@@ -17,72 +17,129 @@ export function ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramS
               {paramName}{equal}<span className='script-param-value'>{value}</span>
             </span>
             <div className='description'>
-              {GetDescriptionForParam(paramName)}
+              {GetDescriptionForParam(paramName, value)}
             </div>
           </span>{commaOrParen}
         </span>
     );
 }
 
-function GetDescriptionForParam(paramName) {
-    const descriptions = {
-        ID: (<span>
-          Hitbox identifier,<br/>
-          hitbox priority is defined by this value with 0 being the highest priority
-        </span>),
-        Part: "Group hitbox is defined into, hitboxes with different part values are considered separate and can hit a single opponent even if another hitbox has landed and hasn't been removed",
-        Bone: "",
-        Damage: "",
-        Angle: "",
-        BKB: (<span>
-          Base KnockBack,<br/>
-          minimum amount of knockback done regardless of damage and percent
-        </span>),
-        FKB: (<span>
-          Fixed KnockBack,<br/>
-          previously known as WBKB (Weight Based KnockBack), if it's not 0 the knockback formula uses this value as opponent's percent and ignores move damage, these moves will deal the same knockback regardless of their damage and percentage the opponent has but still varies by opponent's weight
-        </span>),
-        KBG: (<span>
-          KnockBack Growth,<br/>
-          in the knockback formula describes how much damage and percent scales
-        </span>),
-        Size: "",
-        X: "",
-        Y: "",
-        Z: "",
-        X2: "Stretch coordinate for extended hitboxes",
-        Y2: "Stretch coordinate for extended hitboxes",
-        Z2: "Stretch coordinate for extended hitboxes",
-        Hitlag: "",
-        SDI: "",
-        Clang_Rebound: "",
-        FacingRestrict: "",
-        SetWeight: "Hitbox property that ignores opponent's weight on KB calculation, when enabled every character hit with this hitbox will have their weight set to 100",
-        ShieldDamage: "",
-        Trip: "",
-        Rehit: "If it's not 0 it's the amount of frames a hitbox can hit again an opponent",
-        Reflectable: "",
-        Absorbable: "",
-        Flinchless: "Flag used on hitboxes to not make characters get damage animations nor hitstun but will still receive launch speed, also known as windboxes",
-        DisableHitlag: "Flag that makes hitlag = 0 regardless of damage and hitlag multipliers when enabled",
-        Direct_Hitbox: "",
-        Ground_or_Air: (<span>
-          <span className='description-script'>COLLISION_SITUATION_MASK_A</span>
-          hits opponents in air<br/>
-          <span className='description-script'>COLLISION_SITUATION_MASK_G</span>
-          hits opponents on ground<br/>
-          <span className='description-script'>COLLISION_SITUATION_MASK_GA</span>
-          hits opponents both in air and on ground
-        </span>),
-        Hitbits: "Value where each bit enables it to hit certain hurtboxes like characters, stage elements, items and enemies",
-        CollisionPart: "",
-        FriendlyFire: "Flag used for hitboxes that can hit user and teammates even with friendly fire enabled", // "Team Damage" in Glossary
-        Effect: "",
-        SFXLevel: "",
-        SFXType: (<span>
-          Sound Effect,<br/>represents the ID of the sound file to use when hitbox connects
-        </span>),
-        Type: ""
-    };
-    return descriptions[paramName] || "no description";
+function GetDescriptionForParam(paramName, value) {
+    switch (paramName) {
+        case "ID":
+            return (<span>
+              Hitbox identifier,<br/>
+              hitbox priority is defined by this value with 0 being the highest priority
+            </span>);
+        case "Part":
+            return "Group hitbox is defined into, hitboxes with different part values are considered separate and can hit a single opponent even if another hitbox has landed and hasn't been removed";
+        case "Bone":
+            return "";
+        case "Damage":
+            return "";
+        case "Angle":
+            return "";
+        case "BKB":
+            return (<span>
+              Base KnockBack,<br/>
+              minimum amount of knockback done regardless of damage and percent
+            </span>);
+        case "FKB":
+            return (<span>
+              Fixed KnockBack,<br/>
+              previously known as WBKB (Weight Based KnockBack), if it's not 0 the knockback formula uses this value as opponent's percent and ignores move damage, these moves will deal the same knockback regardless of their damage and percentage the opponent has but still varies by opponent's weight
+            </span>);
+        case "KBG":
+            return (<span>
+              KnockBack Growth,<br/>
+              in the knockback formula describes how much damage and percent scales
+            </span>);
+        case "Size":
+            return "";
+        case "X":
+            return "";
+        case "Y":
+            return "";
+        case "Z":
+            return "";
+        case "X2":
+            return "Stretch coordinate for extended hitboxes";
+        case "Y2":
+            return "Stretch coordinate for extended hitboxes";
+        case "Z2":
+            return "Stretch coordinate for extended hitboxes";
+        case "Hitlag":
+            return "";
+        case "SDI":
+            return "";
+        case "Clang_Rebound":
+            return "";
+        case "FacingRestrict":
+            return "";
+        case "SetWeight":
+            return "Hitbox property that ignores opponent's weight on KB calculation, when enabled every character hit with this hitbox will have their weight set to 100";
+        case "ShieldDamage":
+            return "";
+        case "Trip":
+            return "";
+        case "Rehit":
+            return "If it's not 0 it's the amount of frames a hitbox can hit again an opponent";
+        case "Reflectable":
+            return "";
+        case "Absorbable":
+            return "";
+        case "Flinchless":
+            return "Flag used on hitboxes to not make characters get damage animations nor hitstun but will still receive launch speed, also known as windboxes";
+        case "DisableHitlag":
+            return "Flag that makes hitlag = 0 regardless of damage and hitlag multipliers when enabled";
+        case "Direct_Hitbox":
+            return "";
+        case "Ground_or_Air":
+            const candidateList = [
+                ["COLLISION_SITUATION_MASK_A", "hits opponents in air"],
+                ["COLLISION_SITUATION_MASK_G", "hits opponents on ground"],
+                ["COLLISION_SITUATION_MASK_GA", "hits opponents both in air and on ground"],
+            ];
+            return (
+                <span>
+                  Possible values are:
+                  {DescribeCandidateList(candidateList, value)}
+                </span>);
+        case "Hitbits":
+            return "Value where each bit enables it to hit certain hurtboxes like characters, stage elements, items and enemies";
+        case "CollisionPart":
+            return "";
+        case "FriendlyFire":
+            return "Flag used for hitboxes that can hit user and teammates even with friendly fire enabled"; // "Team Damage" in Glossary
+        case "Effect":
+            return "";
+        case "SFXLevel":
+            return "";
+        case "SFXType":
+            return (<span>
+              Sound Effect,<br/>represents the ID of the sound file to use when hitbox connects
+            </span>);
+        case "Type":
+            return "";
+        default:
+            return "no description";
+    }
+}
+
+function DescribeCandidate(candidate, description, value) {
+    let className = "description-script";
+    if (candidate === value) {
+        className += " current-value";
+    }
+    return (
+        <div>
+          <span className={className}>{candidate}</span>
+          {description}
+        </div>
+    );
+}
+
+function DescribeCandidateList(candidateList, value) {
+    return candidateList.map(([candidate, description]) =>
+        DescribeCandidate(candidate, description, value))
 }

--- a/src/util/ScriptParam.js
+++ b/src/util/ScriptParam.js
@@ -25,6 +25,7 @@ export function ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramS
 }
 
 function GetDescriptionForParam(paramName, value) {
+    let candidateList;
     switch (paramName) {
         case "ID":
             return (<span>
@@ -55,17 +56,16 @@ function GetDescriptionForParam(paramName, value) {
               in the knockback formula describes how much damage and percent scales
             </span>);
         case "Size":
-            return "";
+            return "Size of the hitbox";
         case "X":
-            return "";
         case "Y":
-            return "";
         case "Z":
-            return "";
+            return (<span>
+              Coordinate of the hitbox relative to
+              <span className="description-script">Bone</span>
+            </span>);
         case "X2":
-            return "Stretch coordinate for extended hitboxes";
         case "Y2":
-            return "Stretch coordinate for extended hitboxes";
         case "Z2":
             return "Stretch coordinate for extended hitboxes";
         case "Hitlag":
@@ -75,7 +75,15 @@ function GetDescriptionForParam(paramName, value) {
         case "Clang_Rebound":
             return "";
         case "FacingRestrict":
-            return "";
+            candidateList = [
+                ["ATTACK_LR_CHECK_POS", "no description"],
+                ["ATTACK_LR_CHECK_F", "no description"],
+                ["ATTACK_LR_CHECK_B", "no description"],
+            ]
+            return (<span>
+              Possible values are:
+              {DescribeCandidateList(candidateList, value)}
+            </span>);
         case "SetWeight":
             return "Hitbox property that ignores opponent's weight on KB calculation, when enabled every character hit with this hitbox will have their weight set to 100";
         case "ShieldDamage":
@@ -95,7 +103,7 @@ function GetDescriptionForParam(paramName, value) {
         case "Direct_Hitbox":
             return "";
         case "Ground_or_Air":
-            const candidateList = [
+            candidateList = [
                 ["COLLISION_SITUATION_MASK_A", "hits opponents in air"],
                 ["COLLISION_SITUATION_MASK_G", "hits opponents on ground"],
                 ["COLLISION_SITUATION_MASK_GA", "hits opponents both in air and on ground"],

--- a/src/util/ScriptParam.js
+++ b/src/util/ScriptParam.js
@@ -31,6 +31,8 @@ export function ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramS
 }
 
 function GetDescriptionForParam(paramName, value) {
+    // paramName: string, value: string
+    // 'value' is the current value given for the parameter 'paramName'
     let candidateList;
     switch (paramName) {
         case "ID":
@@ -173,6 +175,7 @@ function DescribeCandidate(candidate, description, value) {
 }
 
 function DescribeCandidateList(candidateList, value) {
+    // 'value' is the current value which will be highlighted in the description
     return candidateList.map(([candidate, description]) =>
         DescribeCandidate(candidate, description, value))
 }

--- a/src/util/ScriptParam.js
+++ b/src/util/ScriptParam.js
@@ -37,9 +37,13 @@ function GetDescriptionForParam(paramName, value) {
         case "Bone":
             return "";
         case "Damage":
-            return "";
+            return "Damage dealt to the opponent";
         case "Angle":
-            return "";
+            return <span>
+              The Angle the opponent is sent.<br/>
+              Angles larger than 360 has special meanings
+              (see <a href="https://www.ssbwiki.com/Angle" target="_blank">SmashWiki</a> for details)
+            </span>;
         case "BKB":
             return (<span>
               Base KnockBack,<br/>
@@ -69,9 +73,12 @@ function GetDescriptionForParam(paramName, value) {
         case "Z2":
             return "Stretch coordinate for extended hitboxes";
         case "Hitlag":
-            return "";
+            return "Multiplier for HitLag";
         case "SDI":
-            return "";
+            return (<span>
+              Multiplier for Smash Directional Influence,<br/>
+              easy to SDI if the value is larger than 1.0
+            </span>);
         case "Clang_Rebound":
             return "";
         case "FacingRestrict":

--- a/src/util/ScriptParam.js
+++ b/src/util/ScriptParam.js
@@ -35,21 +35,33 @@ function GetDescriptionForParam(paramName, value) {
     switch (paramName) {
         case "ID":
             return (<span>
-              Hitbox identifier,<br/>
-              hitbox priority is defined by this value with 0 being the highest priority
-            </span>);
+                  Hitbox identifier,<br/>
+                  hitbox priority is defined by this value with 0 being the highest priority
+                </span>);
         case "Part":
             return "Group hitbox is defined into, hitboxes with different part values are considered separate and can hit a single opponent even if another hitbox has landed and hasn't been removed";
         case "Bone":
-            return "";
+            return (<span>
+              A part of the user which determines the axes for hitboxes
+              in
+              <span className="description-script">X</span>,
+              <span className="description-script">Y</span>,
+              <span className="description-script">Z</span>
+              .<br/>
+              Examples of values:
+              <span className="description-script">top</span>,
+              <span className="description-script">head</span>,
+              <span className="description-script">armr</span>(meaning right arm),
+              <span className="description-script">sword</span>
+            </span>);
         case "Damage":
             return "Damage dealt to the opponent";
         case "Angle":
-            return <span>
+            return (<span>
               The Angle the opponent is sent.<br/>
               Angles larger than 360 has special meanings
               (see <a href="https://www.ssbwiki.com/Angle" target="_blank">SmashWiki</a> for details)
-            </span>;
+            </span>);
         case "BKB":
             return (<span>
               Base KnockBack,<br/>
@@ -86,7 +98,7 @@ function GetDescriptionForParam(paramName, value) {
               easy to SDI if the value is larger than 1.0
             </span>);
         case "Clang_Rebound":
-            return "";
+            return "no description";
         case "FacingRestrict":
             candidateList = [
                 ["ATTACK_LR_CHECK_POS", "no description"],
@@ -100,21 +112,21 @@ function GetDescriptionForParam(paramName, value) {
         case "SetWeight":
             return "Hitbox property that ignores opponent's weight on KB calculation, when enabled every character hit with this hitbox will have their weight set to 100";
         case "ShieldDamage":
-            return "";
+            return "Additional damage for opponent's shield.";
         case "Trip":
-            return "";
+            return "Probability of the opponent tripping";
         case "Rehit":
             return "If it's not 0 it's the amount of frames a hitbox can hit again an opponent";
         case "Reflectable":
-            return "";
+            return "If true, the attack is refelectable (e.g. by Fox's down special)";
         case "Absorbable":
-            return "";
+            return "If true, the attack is absorbable (e.g. by Ness' down special)";
         case "Flinchless":
             return "Flag used on hitboxes to not make characters get damage animations nor hitstun but will still receive launch speed, also known as windboxes";
         case "DisableHitlag":
             return "Flag that makes hitlag = 0 regardless of damage and hitlag multipliers when enabled";
         case "Direct_Hitbox":
-            return "";
+            return "no description";
         case "Ground_or_Air":
             candidateList = [
                 ["COLLISION_SITUATION_MASK_A", "hits opponents in air"],
@@ -129,19 +141,19 @@ function GetDescriptionForParam(paramName, value) {
         case "Hitbits":
             return "Value where each bit enables it to hit certain hurtboxes like characters, stage elements, items and enemies";
         case "CollisionPart":
-            return "";
+            return "no description";
         case "FriendlyFire":
             return "Flag used for hitboxes that can hit user and teammates even with friendly fire enabled"; // "Team Damage" in Glossary
         case "Effect":
-            return "";
+            return "no description";
         case "SFXLevel":
-            return "";
+            return "Loudness of the Sound Effect";
         case "SFXType":
             return (<span>
               Sound Effect,<br/>represents the ID of the sound file to use when hitbox connects
             </span>);
         case "Type":
-            return "";
+            return "no description";
         default:
             return "no description";
     }

--- a/src/util/ScriptParam.js
+++ b/src/util/ScriptParam.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+
+export function ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramStyles) {
+    const paramName = p1;
+    const equal = p2;
+    const value = p3;
+    const commaOrParen = p4;
+    let className = `script-param-${paramName}`;
+    if (paramName in paramStyles) {
+        className += ` param-style-${paramStyles[paramName]}`
+    }
+    return ReactDOMServer.renderToStaticMarkup(
+        <span>
+          <span className={`script-param ${className}`}>
+            <span className='script-param-content' tabIndex='-1'>
+              {paramName}{equal}<span className='script-param-value'>{value}</span>
+            </span>
+            <div className='description'>
+              {GetDescriptionForParam(paramName)}
+            </div>
+          </span>{commaOrParen}
+        </span>
+    );
+}
+
+function GetDescriptionForParam(paramName) {
+    const descriptions = {
+        ID: (<span>
+          Hitbox identifier,<br/>
+          hitbox priority is defined by this value with 0 being the highest priority
+        </span>),
+        Part: "Group hitbox is defined into, hitboxes with different part values are considered separate and can hit a single opponent even if another hitbox has landed and hasn't been removed",
+        Bone: "",
+        Damage: "",
+        Angle: "",
+        BKB: (<span>
+          Base KnockBack,<br/>
+          minimum amount of knockback done regardless of damage and percent
+        </span>),
+        FKB: (<span>
+          Fixed KnockBack,<br/>
+          previously known as WBKB (Weight Based KnockBack), if it's not 0 the knockback formula uses this value as opponent's percent and ignores move damage, these moves will deal the same knockback regardless of their damage and percentage the opponent has but still varies by opponent's weight
+        </span>),
+        KBG: (<span>
+          KnockBack Growth,<br/>
+          in the knockback formula describes how much damage and percent scales
+        </span>),
+        Size: "",
+        X: "",
+        Y: "",
+        Z: "",
+        X2: "Stretch coordinate for extended hitboxes",
+        Y2: "Stretch coordinate for extended hitboxes",
+        Z2: "Stretch coordinate for extended hitboxes",
+        Hitlag: "",
+        SDI: "",
+        Clang_Rebound: "",
+        FacingRestrict: "",
+        SetWeight: "Hitbox property that ignores opponent's weight on KB calculation, when enabled every character hit with this hitbox will have their weight set to 100",
+        ShieldDamage: "",
+        Trip: "",
+        Rehit: "If it's not 0 it's the amount of frames a hitbox can hit again an opponent",
+        Reflectable: "",
+        Absorbable: "",
+        Flinchless: "Flag used on hitboxes to not make characters get damage animations nor hitstun but will still receive launch speed, also known as windboxes",
+        DisableHitlag: "Flag that makes hitlag = 0 regardless of damage and hitlag multipliers when enabled",
+        Direct_Hitbox: "",
+        Ground_or_Air: (<span>
+          <span class='description-script'>COLLISION_SITUATION_MASK_A</span>
+          hits opponents in air<br/>
+          <span class='description-script'>COLLISION_SITUATION_MASK_G</span>
+          hits opponents on ground<br/>
+          <span class='description-script'>COLLISION_SITUATION_MASK_GA</span>
+          hits opponents both in air and on ground
+        </span>),
+        Hitbits: "Value where each bit enables it to hit certain hurtboxes like characters, stage elements, items and enemies",
+        CollisionPart: "",
+        FriendlyFire: "Flag used for hitboxes that can hit user and teammates even with friendly fire enabled", // "Team Damage" in Glossary
+        Effect: "",
+        SFXLevel: "",
+        SFXType: (<span>
+          Sound Effect,<br/>represents the ID of the sound file to use when hitbox connects
+        </span>),
+        Type: ""
+    };
+    return descriptions[paramName] || "no description";
+}

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -36,7 +36,7 @@ function ReplaceScriptParam(match, p1, p2, p3, p4, p5, offset, string, paramStyl
         className += ` param-style-${paramStyles[paramName]}`
     }
     return `<span class='script-param ${className}'>
-  <span class='script-param-content'>
+  <span class='script-param-content' tabindex='-1'>
     ${paramName}${equal}<span class='script-param-value'>${value}</span>
   </span><div class='description'>
     ${GetDescriptionForParam(paramName)}

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,3 +1,5 @@
+import { ReplaceScriptParam } from "./ScriptParam"
+
 export function ToHex(number) {
     var hex = "00000000" + number.toString(16).toUpperCase();
     return "0x" + hex.substr(-8);
@@ -23,25 +25,6 @@ function ToHexWithPadding(number, pad) {
 
 export function IsScriptEmpty(script) {
     return script.Game === null && script.Expression === null && script.Effect === null && script.Sound === null;
-}
-
-function ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramStyles) {
-    const paramName = p1;
-    const equal = p2;
-    const value = p3;
-    const commaOrParen = p4;
-    let className = `script-param-${paramName}`;
-    if (paramName in paramStyles) {
-        className += ` param-style-${paramStyles[paramName]}`
-    }
-    return `<span class='script-param ${className}'>
-  <span class='script-param-content' tabindex='-1'>
-    ${paramName}${equal}<span class='script-param-value'>${value}</span>
-  </span>
-  <div class='description'>
-    ${GetDescriptionForParam(paramName)}
-  </div>
-</span>${commaOrParen}`
 }
 
 function FormatScript(script, paramStyles) {
@@ -254,46 +237,4 @@ export function ParseHurtboxState(state) {
         default:
             return "";
     }
-}
-
-function GetDescriptionForParam(paramName) {
-    const descriptions = {
-        ID: "Hitbox identifier,<br/>hitbox priority is defined by this value with 0 being the highest priority",
-        Part: "Group hitbox is defined into, hitboxes with different part values are considered separate and can hit a single opponent even if another hitbox has landed and hasn't been removed",
-        Bone: "",
-        Damage: "",
-        Angle: "",
-        BKB: "Base KnockBack,<br/>minimum amount of knockback done regardless of damage and percent",
-        FKB: "Fixed KnockBack,<br/>previously known as WBKB (Weight Based KnockBack), if it's not 0 the knockback formula uses this value as opponent's percent and ignores move damage, these moves will deal the same knockback regardless of their damage and percentage the opponent has but still varies by opponent's weight",
-        KBG: "KnockBack Growth,<br/>in the knockback formula describes how much damage and percent scales",
-        Size: "",
-        X: "",
-        Y: "",
-        Z: "",
-        X2: "Stretch coordinate for extended hitboxes",
-        Y2: "Stretch coordinate for extended hitboxes",
-        Z2: "Stretch coordinate for extended hitboxes",
-        Hitlag: "",
-        SDI: "",
-        Clang_Rebound: "",
-        FacingRestrict: "",
-        SetWeight: "Hitbox property that ignores opponent's weight on KB calculation, when enabled every character hit with this hitbox will have their weight set to 100",
-        ShieldDamage: "",
-        Trip: "",
-        Rehit: "If it's not 0 it's the amount of frames a hitbox can hit again an opponent",
-        Reflectable: "",
-        Absorbable: "",
-        Flinchless: "Flag used on hitboxes to not make characters get damage animations nor hitstun but will still receive launch speed, also known as windboxes",
-        DisableHitlag: "Flag that makes hitlag = 0 regardless of damage and hitlag multipliers when enabled",
-        Direct_Hitbox: "",
-        Ground_or_Air: "<span class='description-script'>COLLISION_SITUATION_MASK_A</span>: hits opponents in air<br/><span class='description-script'>COLLISION_SITUATION_MASK_G</span>: hits opponents on ground<br/><span class='description-script'>COLLISION_SITUATION_MASK_GA</span>: hits opponents both in air and on ground",
-        Hitbits: "Value where each bit enables it to hit certain hurtboxes like characters, stage elements, items and enemies",
-        CollisionPart: "",
-        FriendlyFire: "Flag used for hitboxes that can hit user and teammates even with friendly fire enabled", // "Team Damage" in Glossary
-        Effect: "",
-        SFXLevel: "",
-        SFXType: "Sound Effect,<br/>represents the ID of the sound file to use when hitbox connects",
-        Type: ""
-    };
-    return descriptions[paramName] || "no description";
 }

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -257,22 +257,43 @@ export function ParseHurtboxState(state) {
 }
 
 function GetDescriptionForParam(paramName) {
-  const descriptions = {
-    ID: "Hitbox identifier,<br/>hitbox priority is defined by this value with 0 being the highest priority",
-    Part: "Group hitbox is defined into, hitboxes with different part values are considered separate and can hit a single opponent even if another hitbox has landed and hasn't been removed",
-    BKB: "Base KnockBack,<br/>minimum amount of knockback done regardless of damage and percent",
-    FKB: "Fixed KnockBack,<br/>previously known as WBKB (Weight Based KnockBack), if it's not 0 the knockback formula uses this value as opponent's percent and ignores move damage, these moves will deal the same knockback regardless of their damage and percentage the opponent has but still varies by opponent's weight",
-    KBG: "KnockBack Growth,<br/>in the knockback formula describes how much damage and percent scales",
-    SFXType: "Sound Effect,<br/>represents the ID of the sound file to use when hitbox connects",
-    Hitbits: "Value where each bit enables it to hit certain hurtboxes like characters, stage elements, items and enemies",
-    Rehit: "If it's not 0 it's the amount of frames a hitbox can hit again an opponent",
-    FriendlyFire: "Flag used for hitboxes that can hit user and teammates even with friendly fire enabled", // "Team Damage" in Glossary
-    Flinchless: "Flag used on hitboxes to not make characters get damage animations nor hitstun but will still receive launch speed, also known as windboxes",
-    DisableHitlag: "Flag that makes hitlag = 0 regardless of damage and hitlag multipliers when enabled",
-    X2: "Stretch coordinate for extended hitboxes",
-    Y2: "Stretch coordinate for extended hitboxes",
-    Z2: "Stretch coordinate for extended hitboxes",
-    SetWeight: "Hitbox property that ignores opponent's weight on KB calculation, when enabled every character hit with this hitbox will have their weight set to 100",
-  };
-  return descriptions[paramName] || "no description";
+    const descriptions = {
+        ID: "Hitbox identifier,<br/>hitbox priority is defined by this value with 0 being the highest priority",
+        Part: "Group hitbox is defined into, hitboxes with different part values are considered separate and can hit a single opponent even if another hitbox has landed and hasn't been removed",
+        Bone: "",
+        Damage: "",
+        Angle: "",
+        BKB: "Base KnockBack,<br/>minimum amount of knockback done regardless of damage and percent",
+        FKB: "Fixed KnockBack,<br/>previously known as WBKB (Weight Based KnockBack), if it's not 0 the knockback formula uses this value as opponent's percent and ignores move damage, these moves will deal the same knockback regardless of their damage and percentage the opponent has but still varies by opponent's weight",
+        KBG: "KnockBack Growth,<br/>in the knockback formula describes how much damage and percent scales",
+        Size: "",
+        X: "",
+        Y: "",
+        Z: "",
+        X2: "Stretch coordinate for extended hitboxes",
+        Y2: "Stretch coordinate for extended hitboxes",
+        Z2: "Stretch coordinate for extended hitboxes",
+        Hitlag: "",
+        SDI: "",
+        Clang_Rebound: "",
+        FacingRestrict: "",
+        SetWeight: "Hitbox property that ignores opponent's weight on KB calculation, when enabled every character hit with this hitbox will have their weight set to 100",
+        ShieldDamage: "",
+        Trip: "",
+        Rehit: "If it's not 0 it's the amount of frames a hitbox can hit again an opponent",
+        Reflectable: "",
+        Absorbable: "",
+        Flinchless: "Flag used on hitboxes to not make characters get damage animations nor hitstun but will still receive launch speed, also known as windboxes",
+        DisableHitlag: "Flag that makes hitlag = 0 regardless of damage and hitlag multipliers when enabled",
+        Direct_Hitbox: "",
+        Ground_or_Air: "<span class='description-script'>COLLISION_SITUATION_MASK_A</span>: hits opponents in air<br/><span class='description-script'>COLLISION_SITUATION_MASK_G</span>: hits opponents on ground<br/><span class='description-script'>COLLISION_SITUATION_MASK_GA</span>: hits opponents both in air and on ground",
+        Hitbits: "Value where each bit enables it to hit certain hurtboxes like characters, stage elements, items and enemies",
+        CollisionPart: "",
+        FriendlyFire: "Flag used for hitboxes that can hit user and teammates even with friendly fire enabled", // "Team Damage" in Glossary
+        Effect: "",
+        SFXLevel: "",
+        SFXType: "Sound Effect,<br/>represents the ID of the sound file to use when hitbox connects",
+        Type: ""
+    };
+    return descriptions[paramName] || "no description";
 }

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -25,12 +25,11 @@ export function IsScriptEmpty(script) {
     return script.Game === null && script.Expression === null && script.Effect === null && script.Sound === null;
 }
 
-function ReplaceScriptParam(match, p1, p2, p3, p4, p5, offset, string, paramStyles) {
+function ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramStyles) {
     const paramName = p1;
     const equal = p2;
     const value = p3;
-    const comma = p4;
-    const closeParen = p5;
+    const commaOrParen = p4;
     let className = `script-param-${paramName}`;
     if (paramName in paramStyles) {
         className += ` param-style-${paramStyles[paramName]}`
@@ -38,10 +37,11 @@ function ReplaceScriptParam(match, p1, p2, p3, p4, p5, offset, string, paramStyl
     return `<span class='script-param ${className}'>
   <span class='script-param-content' tabindex='-1'>
     ${paramName}${equal}<span class='script-param-value'>${value}</span>
-  </span><div class='description'>
+  </span>
+  <div class='description'>
     ${GetDescriptionForParam(paramName)}
-  </div>${comma}
-</span>${closeParen}`
+  </div>
+</span>${commaOrParen}`
 }
 
 function FormatScript(script, paramStyles) {
@@ -53,8 +53,8 @@ function FormatScript(script, paramStyles) {
     /* .replace(/(=)(-?[0-9A-Za-z_]+x?\.?[0-9A-Za-z_]*)(,|\))/g, "$1<span class='script-param-value'>$2</span>$3") */
     /* .replace(/([A-Za-z\/_]*)(=)(-?[0-9A-Za-z_]+x?\.?[0-9A-Za-z_]*)(,?)(\)?)/g,
      *          "<span class='script-param-$1'>$1$2<span class='script-param-value'>$3</span>$4</span>$5") */
-            .replace(/([0-9A-Za-z\/_]*)(=)(-?[0-9A-Za-z_\(\)\"]+x?\.?[0-9A-Za-z_]*)(,?)(\)?)/g,
-                     (match, p1, p2, p3, p4, p5, offset, string) => ReplaceScriptParam(match, p1, p2, p3, p4, p5, offset, string, paramStyles))
+            .replace(/([0-9A-Za-z\/_]*)(=)(-?[0-9A-Za-z_\(\)\"]+x?\.?[0-9A-Za-z_]*)(,|\))/g,
+                     (match, p1, p2, p3, p4, p5, offset, string) => ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramStyles))
             .replace(/([a-zA-Z_0-9\.\:/]+)(\()/g, "<span class='script-cmd'>$1</span>$2")
             .replace(/<span><\/span>/g, "");
 }

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -35,7 +35,13 @@ function ReplaceScriptParam(match, p1, p2, p3, p4, p5, offset, string, paramStyl
     if (paramName in paramStyles) {
         className += ` param-style-${paramStyles[paramName]}`
     }
-    return `<span class='${className}'><span class='script-param-content'>${paramName}${equal}<span class='script-param-value'>${value}</span></span>${comma}</span>${closeParen}`
+    return `<span class='script-param ${className}'>
+  <span class='script-param-content'>
+    ${paramName}${equal}<span class='script-param-value'>${value}</span>
+  </span><div class='description'>
+    ${GetDescriptionForParam(paramName)}
+  </div>${comma}
+</span>${closeParen}`
 }
 
 function FormatScript(script, paramStyles) {
@@ -248,4 +254,25 @@ export function ParseHurtboxState(state) {
         default:
             return "";
     }
+}
+
+function GetDescriptionForParam(paramName) {
+  const descriptions = {
+    ID: "Hitbox identifier,<br/>hitbox priority is defined by this value with 0 being the highest priority",
+    Part: "Group hitbox is defined into, hitboxes with different part values are considered separate and can hit a single opponent even if another hitbox has landed and hasn't been removed",
+    BKB: "Base KnockBack,<br/>minimum amount of knockback done regardless of damage and percent",
+    FKB: "Fixed KnockBack,<br/>previously known as WBKB (Weight Based KnockBack), if it's not 0 the knockback formula uses this value as opponent's percent and ignores move damage, these moves will deal the same knockback regardless of their damage and percentage the opponent has but still varies by opponent's weight",
+    KBG: "KnockBack Growth,<br/>in the knockback formula describes how much damage and percent scales",
+    SFXType: "Sound Effect,<br/>represents the ID of the sound file to use when hitbox connects",
+    Hitbits: "Value where each bit enables it to hit certain hurtboxes like characters, stage elements, items and enemies",
+    Rehit: "If it's not 0 it's the amount of frames a hitbox can hit again an opponent",
+    FriendlyFire: "Flag used for hitboxes that can hit user and teammates even with friendly fire enabled", // "Team Damage" in Glossary
+    Flinchless: "Flag used on hitboxes to not make characters get damage animations nor hitstun but will still receive launch speed, also known as windboxes",
+    DisableHitlag: "Flag that makes hitlag = 0 regardless of damage and hitlag multipliers when enabled",
+    X2: "Stretch coordinate for extended hitboxes",
+    Y2: "Stretch coordinate for extended hitboxes",
+    Z2: "Stretch coordinate for extended hitboxes",
+    SetWeight: "Hitbox property that ignores opponent's weight on KB calculation, when enabled every character hit with this hitbox will have their weight set to 100",
+  };
+  return descriptions[paramName] || "no description";
 }

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -37,7 +37,7 @@ function FormatScript(script, paramStyles) {
     /* .replace(/([A-Za-z\/_]*)(=)(-?[0-9A-Za-z_]+x?\.?[0-9A-Za-z_]*)(,?)(\)?)/g,
      *          "<span class='script-param-$1'>$1$2<span class='script-param-value'>$3</span>$4</span>$5") */
             .replace(/([0-9A-Za-z\/_]*)(=)(-?[0-9A-Za-z_\(\)\"]+x?\.?[0-9A-Za-z_]*)(,|\))/g,
-                     (match, p1, p2, p3, p4, p5, offset, string) => ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramStyles))
+                     (match, p1, p2, p3, p4, offset, string) => ReplaceScriptParam(match, p1, p2, p3, p4, offset, string, paramStyles))
             .replace(/([a-zA-Z_0-9\.\:/]+)(\()/g, "<span class='script-cmd'>$1</span>$2")
             .replace(/<span><\/span>/g, "");
 }


### PR DESCRIPTION
This is an implementation of #17.

All of the descriptions are written in the function `GetDescriptionForParam` in `src/util/ScriptParam.js` within JSX (React).
Could you please fix the descriptions?
(Descriptions I couldn't write are marked as `"no description"`)

Note that you can use the function `DescribeCandidateList` for the parameters that have few numbers of candidates of values. See `Ground_or_Air` for an example; the current value is highlighted as follows:
![Screenshot from 2020-12-03 19-59-40](https://user-images.githubusercontent.com/18346326/101001183-23692700-35a2-11eb-8e69-c94c7b917ae5.png)

## Question
I referred [Glossary](https://rubendal.github.io/ssbu/#/Glossary) to write some of the parameters and I found the description of "Team Damage":

> Team Damage: Flag used for hitboxes that can hit user and teammates even with friendly fire enabled

But, if I understand correctly, it contains a typo and should be "even with friendly fire *disabled*".
If friendly fire enabled, *all* attacks hit teammates.
Am I correct? Or is there some misunderstanding?
